### PR TITLE
feat: change default timestamp columns to 'created' and 'updated'

### DIFF
--- a/docs/schema-builders.md
+++ b/docs/schema-builders.md
@@ -57,13 +57,13 @@ Removes a column from the table (ALTER TABLE only).
 #### timestamps()
 
 ```php
-public function timestamps(string $createdColumn = 'created_at', string $updatedColumn = 'updated_at'): void
+public function timestamps(string $createdColumn = 'created', string $updatedColumn = 'updated'): void
 ```
 
-Adds automatic timestamp management with MySQL triggers. Creates two TIMESTAMP columns and a trigger to automatically update the updated_at column on record changes.
+Adds automatic timestamp management with MySQL triggers. Creates two TIMESTAMP columns and a trigger to automatically update the updated column on record changes.
 
 ```php
-// Use default column names (created_at, updated_at)
+// Use default column names (created, updated)
 $table->timestamps();
 
 // Use custom column names
@@ -71,8 +71,8 @@ $table->timestamps('created_on', 'modified_on');
 ```
 
 **Note:** This creates:
-- A `created_at/created_on` column with `DEFAULT CURRENT_TIMESTAMP`
-- An `updated_at/modified_on` column with `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`
+- A `created/created_on` column with `DEFAULT CURRENT_TIMESTAMP`
+- An `updated/modified_on` column with `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`
 - A MySQL trigger to automatically update the updated column on UPDATE operations
 
 #### dropTimestampTrigger()
@@ -300,20 +300,20 @@ The dry-dbi library provides automatic timestamp management through MySQL trigge
 When you call `timestamps()` on a TableBuilder:
 
 1. **Column Creation**: Two TIMESTAMP columns are added to your table
-   - `created_at` (or custom name): Set to `CURRENT_TIMESTAMP` when record is created
-   - `updated_at` (or custom name): Set to `CURRENT_TIMESTAMP` and updated automatically on changes
+   - `created` (or custom name): Set to `CURRENT_TIMESTAMP` when record is created
+   - `updated` (or custom name): Set to `CURRENT_TIMESTAMP` and updated automatically on changes
 
-2. **Trigger Creation**: A MySQL trigger is created with the naming convention `{table_name}_updated_at_trigger`
+2. **Trigger Creation**: A MySQL trigger is created with the naming convention `{table_name}_updated_trigger`
 
-3. **Automatic Updates**: The trigger automatically updates the `updated_at` column whenever any field in the record is modified
+3. **Automatic Updates**: The trigger automatically updates the `updated` column whenever any field in the record is modified
 
 ### Trigger Naming Convention
 
-Auto-generated triggers follow this pattern: `{table_name}_updated_at_trigger`
+Auto-generated triggers follow this pattern: `{table_name}_updated_trigger`
 
 For example:
-- Table `users` → Trigger `users_updated_at_trigger`
-- Table `blog_posts` → Trigger `blog_posts_updated_at_trigger`
+- Table `users` → Trigger `users_updated_trigger`
+- Table `blog_posts` → Trigger `blog_posts_updated_trigger`
 
 ### Best Practices
 
@@ -377,8 +377,8 @@ $qb->table('users')
 // Remove timestamp functionality from a table
 $qb->table('users')
    ->alter(function(TableBuilder $table) {
-       $table->dropColumn('created_at');
-       $table->dropColumn('updated_at');
+       $table->dropColumn('created');
+       $table->dropColumn('updated');
        $table->dropTimestampTriggers();
    });
 

--- a/src/TableBuilder.php
+++ b/src/TableBuilder.php
@@ -177,7 +177,7 @@ class TableBuilder extends BuildHandler
      * @param string $updatedColumn
      * @return void
      */
-    public function timestamps(string $createdColumn = 'created_at', string $updatedColumn = 'updated_at'): void {
+    public function timestamps(string $createdColumn = 'created', string $updatedColumn = 'updated'): void {
         $this->timestamps = [
             'created' => $createdColumn,
             'updated' => $updatedColumn
@@ -198,7 +198,7 @@ class TableBuilder extends BuildHandler
      */
     public function dropTimestampTriggers(): void {
         $tableName = $this->getTable();
-        $this->dropTriggers[] = $tableName . '_updated_at_trigger';
+        $this->dropTriggers[] = $tableName . '_updated_trigger';
     }
 
     /**
@@ -278,7 +278,7 @@ class TableBuilder extends BuildHandler
             $tableName = $this->getTable();
             $updatedColumn = $this->timestamps['updated'];
             
-            $triggerName = $tableName . '_updated_at_trigger';
+            $triggerName = $tableName . '_updated_trigger';
             
             $this->addToQuery('; DROP TRIGGER IF EXISTS ' . $this->quote($triggerName));
             
@@ -300,6 +300,6 @@ class TableBuilder extends BuildHandler
         }
         
         $tableName = $this->getTable();
-        return [$tableName . '_updated_at_trigger'];
+        return [$tableName . '_updated_trigger'];
     }
 }

--- a/tests/Feature/TimestampsTest.php
+++ b/tests/Feature/TimestampsTest.php
@@ -15,8 +15,8 @@ describe('TableBuilder Timestamps', function () {
         $query = $tableBuilder->getQuery();
         
         expect($query)
-            ->toContain('`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
-            ->toContain('`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+            ->toContain('`created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
+            ->toContain('`updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
             ->not->toContain('CREATE TRIGGER'); // No triggers for CREATE TABLE
     });
 
@@ -45,27 +45,27 @@ describe('TableBuilder Timestamps', function () {
         $query = $tableBuilder->getQuery();
         
         expect($query)
-            ->toContain('ADD `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
-            ->toContain('ADD `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
-            ->toContain('CREATE TRIGGER `existing_table_updated_at_trigger`')
+            ->toContain('ADD `created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
+            ->toContain('ADD `updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+            ->toContain('CREATE TRIGGER `existing_table_updated_trigger`')
             ->toContain('BEFORE UPDATE ON `existing_table`')
-            ->toContain('SET NEW.`updated_at` = CURRENT_TIMESTAMP');
+            ->toContain('SET NEW.`updated` = CURRENT_TIMESTAMP');
     });
 
     it('drops timestamp triggers and columns', function () {
         $tableBuilder = new TableBuilder(true);
         $tableBuilder->table('users');
-        $tableBuilder->dropColumn('created_at');
-        $tableBuilder->dropColumn('updated_at');
+        $tableBuilder->dropColumn('created');
+        $tableBuilder->dropColumn('updated');
         $tableBuilder->dropTimestampTriggers();
         $tableBuilder->build();
         
         $query = $tableBuilder->getQuery();
         
         expect($query)
-            ->toContain('DROP COLUMN `created_at`')
-            ->toContain('DROP COLUMN `updated_at`')
-            ->toContain('DROP TRIGGER IF EXISTS `users_updated_at_trigger`');
+            ->toContain('DROP COLUMN `created`')
+            ->toContain('DROP COLUMN `updated`')
+            ->toContain('DROP TRIGGER IF EXISTS `users_updated_trigger`');
     });
 
     it('generates correct trigger names', function () {
@@ -76,7 +76,7 @@ describe('TableBuilder Timestamps', function () {
         
         $triggerNames = $tableBuilder->getGeneratedTriggerNames();
         
-        expect($triggerNames)->toBe(['test_table_updated_at_trigger']);
+        expect($triggerNames)->toBe(['test_table_updated_trigger']);
     });
 
     it('handles complex table with timestamps and constraints', function () {
@@ -94,8 +94,8 @@ describe('TableBuilder Timestamps', function () {
         $query = $tableBuilder->getQuery();
         
         expect($query)
-            ->toContain('`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
-            ->toContain('`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+            ->toContain('`created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
+            ->toContain('`updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
             ->toContain('CONSTRAINT `uq_slug` UNIQUE (`slug`)')
             ->toContain('FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE CASCADE');
     });
@@ -118,7 +118,7 @@ describe('TableBuilder Timestamps', function () {
             ->toContain('DROP COLUMN `obsolete_field`')
             ->toContain('ADD `date_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
             ->toContain('ADD `date_updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
-            ->toContain('CREATE TRIGGER `legacy_table_updated_at_trigger`')
+            ->toContain('CREATE TRIGGER `legacy_table_updated_trigger`')
             ->toContain('SET NEW.`date_updated` = CURRENT_TIMESTAMP');
     });
 
@@ -127,16 +127,16 @@ describe('TableBuilder Timestamps', function () {
         $cleanupBuilder = new TableBuilder(true);
         $cleanupBuilder->table('products');
         $cleanupBuilder->dropTimestampTriggers();
-        $cleanupBuilder->dropColumn('created_at');
-        $cleanupBuilder->dropColumn('updated_at');
+        $cleanupBuilder->dropColumn('created');
+        $cleanupBuilder->dropColumn('updated');
         $cleanupBuilder->build();
         
         $cleanupQuery = $cleanupBuilder->getQuery();
         
         expect($cleanupQuery)
-            ->toContain('DROP TRIGGER IF EXISTS `products_updated_at_trigger`')
-            ->toContain('DROP COLUMN `created_at`')
-            ->toContain('DROP COLUMN `updated_at`');
+            ->toContain('DROP TRIGGER IF EXISTS `products_updated_trigger`')
+            ->toContain('DROP COLUMN `created`')
+            ->toContain('DROP COLUMN `updated`');
         
         // Step 2: Add new timestamp configuration
         $newBuilder = new TableBuilder(true);
@@ -149,7 +149,7 @@ describe('TableBuilder Timestamps', function () {
         expect($newQuery)
             ->toContain('ADD `creation_date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP')
             ->toContain('ADD `modification_date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
-            ->toContain('CREATE TRIGGER `products_updated_at_trigger`')
+            ->toContain('CREATE TRIGGER `products_updated_trigger`')
             ->toContain('SET NEW.`modification_date` = CURRENT_TIMESTAMP');
     });
 


### PR DESCRIPTION
Update default timestamp column names for better simplicity:
- Change default from 'created_at'/'updated_at' to 'created'/'updated'
- Update trigger naming from '{table}_updated_at_trigger' to '{table}_updated_trigger'
- Maintain backward compatibility through customizable column names
- Update all tests and documentation to reflect new defaults

Provides cleaner, more concise default column naming while preserving full customization capabilities.